### PR TITLE
feat: add rootState.set to update multiple models at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Below is the API for `withDefaultReducers` and the reducers it generates.
 
 ### `withDefaultReducers(models, [opts])`
 
+> the named and only export of `rematch-default-reducer`
+
 - `models: {[modelName]: {state: any, reducers?: {[reducerName]: function}}}`
   - the `models` config expected by `init()` from `@rematch/core`
   - `state` may not contain `null` or `undefined` values, or else `TypeError`
@@ -70,7 +72,11 @@ Below is the API for `withDefaultReducers` and the reducers it generates.
 
 ---
 
-### `dispatch.${modelName}.set(payload, [meta])`
+### **Common Default Reducers**
+
+> these default reducers are provided for all models
+
+#### `dispatch.${modelName}.set(payload, [meta])`
 
 - `payload`: `any` (required) - the value to set `${modelName}.state` to
 
@@ -95,22 +101,34 @@ When `${modelName}.state` is **NOT** a `{}`-Object
 
 ---
 
-### `dispatch.${modelName}.reset()`
+#### `dispatch.${modelName}.reset()`
 
 Sets `${modelName}.state` to the value it was initialized with.
 
 ---
 
-### `dispatch.rootState.reset()`
+### **The `rootState` Model and Reducers**
+
+> `withDefaultReducers` adds a pseudo-model called `rootState`. It has no
+> `state` of its own, and only exists to provide a couple default reducers for
+> performing updates across multiple models in a single action.
+
+#### `dispatch.rootState.set(payload, [meta])`
+
+- `payload: {[modelName: string]: any}` - an updater object which will
+  effectively be deep-merged with the `redux` store in order to produce the next
+  state in a single action.
+- `meta?: {typeCheck?: boolean}` (optional) - options for the currently
+  dispatched action
+  - `typeCheck?: boolean` (optional) - enables/disables type-checking that
+    prevents `set` from altering the type/interface of the model. **Default:
+    `true`**.
+
+---
+
+#### `dispatch.rootState.reset()`
 
 Resets all models back to their initial state.
-
-`withDefaultReducers` adds a pseudo-model to the `models` config called
-`rootState`. This model has no `state` but receives one default reducer called
-`reset`.
-
-All models get a default reducer called `rootState/reset`, which is triggered by
-`dispatch.rootState.reset()` and resets each model to its initial state.
 
 ---
 

--- a/__test__/rootState.test.js
+++ b/__test__/rootState.test.js
@@ -17,6 +17,50 @@ context('Integration with @rematch/core', function() {
 
   context('rootState action(s)', function() {
     specify(
+      "dispatch.rootState.set can update any and all models' state",
+      function() {
+        const updater = {
+          modelWithObjectState: {
+            isBoolean: false,
+            someString: 'false',
+            someNumber: 2,
+            words: ['hey'],
+            obj: {
+              otherString: 'jk',
+              otherNumber: 11,
+              otherBoolean: true,
+              otherWords: ['hiya'],
+              otherObj: {deep: 'much derp'},
+            },
+            unusualType: new Map([['thing', 'muh thing']]),
+          },
+
+          modelWithArrayState: ['of mind', 'or something'],
+          modelWithStringState: 'bean',
+          modelWithBooleanState: false,
+          modelWithNumberState: 10,
+          modelWithUnusualState: new Map([['wut', /wut/]]),
+        }
+
+        const expected = R.mergeDeepRight(getState(), updater)
+        dispatch.rootState.set(updater)
+        const actual = getState()
+
+        expect(actual).to.deep.equal(expected)
+      }
+    )
+
+    specify(
+      'rootState.set does not alter any model unless specified in the updater argument',
+      function() {
+        const expected = getState()
+        dispatch.rootState.set({nonExistent: 'nope'})
+        const actual = getState()
+
+        expect(actual).to.deep.equal(expected)
+      }
+    )
+    specify(
       'dispatch.rootState.reset resets all models to initial state',
       function() {
         const initialRootState = getState()

--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,10 @@ export const withDefaultReducers = (models, opts = {}) => {
         R.identity,
       ]),
       R.mergeDeepRight({
-        rootState: {reducers: {reset: () => null}, state: null},
+        rootState: {
+          reducers: {reset: R.identity, set: R.identity},
+          state: null,
+        },
       })
     )
   )

--- a/src/lib/handleStateArray.js
+++ b/src/lib/handleStateArray.js
@@ -31,7 +31,22 @@ export const handleInitialStateArray = R.curry(
       replace: _replace,
       reset: () => initialState,
       'rootState/reset': () => initialState,
-      set: _createTypedSetterFor(opts, initialState, modelName),
+      'rootState/set': (state, payload) => {
+        return payload[modelName]
+          ? _createTypedSetterFor({
+              opts,
+              initialState,
+              modelName,
+              actionName: 'rootState/set',
+            })(state, payload[modelName])
+          : state
+      },
+      set: _createTypedSetterFor({
+        opts,
+        initialState,
+        modelName,
+        actionName: `${modelName}/set`,
+      }),
       shift: _shiftN,
       unshift: _unshift,
     }

--- a/src/lib/handleStateObj.js
+++ b/src/lib/handleStateObj.js
@@ -147,7 +147,22 @@ export const handleInitialStateObject = R.curry(
         R.merge({
           reset: () => initialState,
           'rootState/reset': () => initialState,
-          set: _createTypedSetterFor(opts, initialState, modelName),
+          'rootState/set': (state, payload) => {
+            return payload[modelName]
+              ? _createTypedSetterFor({
+                  opts,
+                  initialState,
+                  modelName,
+                  actionName: 'rootState/set',
+                })(state, payload[modelName])
+              : state
+          },
+          set: _createTypedSetterFor({
+            opts,
+            initialState,
+            modelName,
+            actionName: `${modelName}/set`,
+          }),
         })
       )
     )

--- a/src/lib/handleStatePrimitives.js
+++ b/src/lib/handleStatePrimitives.js
@@ -10,7 +10,7 @@ const _guardTypes = R.curry((opts, reducers, initialState, modelName) =>
 
       if (typeCheck && R.not(R.equals(initialStateType, R.type(result)))) {
         throw new TypeError(
-          `${modelName} was initialized as a(n) ${initialStateType}, but dispatch.${modelName}.${reducerName}() attempted to perform an operation that would set it to a non-${initialStateType} value. You should only set your models and their properties to values of the type with which you initialize them.`
+          `${modelName} was initialized as a(n) ${initialStateType}, but ${modelName}/${reducerName} attempted to perform an operation that would set it to a non-${initialStateType} value. You should only set your models and their properties to values of the type with which you initialize them.`
         )
       }
 
@@ -24,6 +24,8 @@ export const handleInitialStateOther = R.curry(
     const createOtherTypesReducers = _guardTypes(opts)({
       reset: () => initialState,
       'rootState/reset': () => initialState,
+      'rootState/set': (state, payload) =>
+        payload[modelName] === undefined ? state : payload[modelName],
       set: _returnSecondArg,
     })
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -50,43 +50,46 @@ export const _toPropSetter = R.curry((propName, setter, state, payload) => ({
   [propName]: setter(state[propName], payload),
 }))
 
-export const _createTypedSetterFor = R.curry(
-  /* eslint-disable-next-line fp/no-nil */
-  (opts, initialState, modelName, state, payload, meta = {}) => {
-    const {typeCheck} = R.merge(opts, meta)
-    const initialType = R.type(initialState)
-    const payloadType = R.type(payload)
-    const isCorrectType = payloadType === initialType
+/* eslint-disable-next-line fp/no-nil */
+export const _createTypedSetterFor = ({
+  opts,
+  initialState,
+  modelName,
+  actionName,
+}) => (state, payload, meta = {}) => {
+  const {typeCheck} = R.merge(opts, meta)
+  const initialType = R.type(initialState)
+  const payloadType = R.type(payload)
+  const isCorrectType = payloadType === initialType
 
-    if (!typeCheck && R.all(isVanillaObj)([initialState, payload])) {
-      return R.mergeDeepRight(state, payload)
-    }
-    if (!typeCheck) return payload
+  if (!typeCheck && R.all(isVanillaObj)([initialState, payload])) {
+    return R.mergeDeepRight(state, payload)
+  }
+  if (!typeCheck) return payload
 
-    if (isCorrectType && !isVanillaObj(payload)) return payload
-    if (!isCorrectType) {
-      /* eslint-disable-next-line fp/no-unused-expression */
-      const payloadString = JSON.stringify(payload, null, '  ')
-      throw new TypeError(
-        `[rematch/withDefaulReducers]: The \`payload\` of dispatch.${modelName}.set() does not satisfy the model's initial interface.\nModel "${modelName}" was initialized as type: ${initialType}\nBut tried to set: ${payloadString}\n\nTo avoid this error you should initialize your models with the exact interface/types your application expects AND avoid setting values that do not satify that interface (best-practice)\nOr if you wish to disable type checking, you can:\n1.) Disable type checking on individual dispatches by passing your action dispatchers {typeCheck: false} as the 2nd (\`meta\`) argument.\n\tE.g. dispatch.model.action(payload, {typeCheck: false})\n2.) Disable type checking for all default reducers by passing {typeCheck: false} as an option to \`withDefaultReducers\`.\n\n`
-      )
-    }
-
-    const altersInterfaceOf = R.complement(R.where(_toInterfaceSpec(payload)))
-
-    if (!altersInterfaceOf(initialState)) {
-      return R.mergeDeepRight(state, payload)
-    }
-
-    const iface = _describeInterface(initialState)
-    const initialInterface = JSON.stringify(iface, null, '  ')
-    const payloadString = JSON.stringify(payload, null, '  ')
+  if (isCorrectType && !isVanillaObj(payload)) return payload
+  if (!isCorrectType) {
     /* eslint-disable-next-line fp/no-unused-expression */
+    const payloadString = JSON.stringify(payload, null, '  ')
     throw new TypeError(
-      `[rematch/withDefaulReducers]: dispatch.${modelName}.set() attempted to alter the model's interface by setting values that differ from those with which the model was initialized.\n\nInitial interface for ${modelName}:\n ${initialInterface}\n\n Values attempted to set:\n${payloadString}\n\nTo avoid this error you should initialize your models with the exact interface/types your application expects AND avoid setting values that do not satify that interface (best-practice)\nOr if you wish to disable type checking, you can:\n1.) Disable type checking on individual dispatches by passing your action dispatchers {typeCheck: false} as the 2nd (\`meta\`) argument.\n\tE.g. dispatch.model.action(payload, {typeCheck: false})\n2.) Disable type checking for all default reducers by passing {typeCheck: false} as an option to \`withDefaultReducers\`.\n\n`
+      `[rematch/withDefaulReducers]: The \`payload\` of ${actionName} does not satisfy ${modelName}'s initial interface.\n"${modelName}" was initialized as type: ${initialType}\nBut tried to set: ${payloadString}\n\nTo avoid this error you should initialize your models with the exact interface/types your application expects AND avoid setting values that do not satify that interface (best-practice)\nOr if you wish to disable type checking, you can:\n1.) Disable type checking on individual dispatches by passing your action dispatchers {typeCheck: false} as the 2nd (\`meta\`) argument.\n\tE.g. dispatch.model.action(payload, {typeCheck: false})\n2.) Disable type checking for all default reducers by passing {typeCheck: false} as an option to \`withDefaultReducers\`.\n\n`
     )
   }
-)
+
+  const altersInterfaceOf = R.complement(R.where(_toInterfaceSpec(payload)))
+
+  if (!altersInterfaceOf(initialState)) {
+    return R.mergeDeepRight(state, payload)
+  }
+
+  const iface = _describeInterface(initialState)
+  const initialInterface = JSON.stringify(iface, null, '  ')
+  const payloadString = JSON.stringify(payload, null, '  ')
+  /* eslint-disable-next-line fp/no-unused-expression */
+  throw new TypeError(
+    `[rematch/withDefaulReducers]: ${actionName} attempted to alter ${modelName}'s interface by setting values that differ from those with which ${modelName} was initialized.\n\nInitial interface for ${modelName}:\n ${initialInterface}\n\n Values attempted to set:\n${payloadString}\n\nTo avoid this error you should initialize your models with the exact interface/types your application expects AND avoid setting values that do not satify that interface (best-practice)\nOr if you wish to disable type checking, you can:\n1.) Disable type checking on individual dispatches by passing your action dispatchers {typeCheck: false} as the 2nd (\`meta\`) argument.\n\tE.g. dispatch.model.action(payload, {typeCheck: false})\n2.) Disable type checking for all default reducers by passing {typeCheck: false} as an option to \`withDefaultReducers\`.\n\n`
+  )
+}
 
 export const _createTypedPropSetterFor = R.curry(
   /* eslint-disable-next-line fp/no-nil, fp/no-unused-expression */


### PR DESCRIPTION
added `rootState.set` default reducer and added `rootState/set` default reducers on all models to
handle rootState updates across multiple models